### PR TITLE
Return gracefully if the class has no params.

### DIFF
--- a/lib/puppet-lint/plugins/duplicate_class_parameters.rb
+++ b/lib/puppet-lint/plugins/duplicate_class_parameters.rb
@@ -3,6 +3,9 @@ PuppetLint.new_check(:duplicate_class_parameters) do
     class_indexes.each do |class_idx|
       seen = Hash.new(0)
 
+      # if there are no params there is nothing to do, return early.
+      return if class_idx[:param_tokens].nil?
+
       class_idx[:param_tokens].each do |token|
         class_name = class_idx[:name_token].value
 

--- a/spec/puppet-lint/plugins/puppet-lint_duplicate_class_parameters_spec.rb
+++ b/spec/puppet-lint/plugins/puppet-lint_duplicate_class_parameters_spec.rb
@@ -1,6 +1,23 @@
 require 'spec_helper'
 
 describe 'duplicate_class_parameters' do
+
+  context 'class with no parameters' do
+   let(:code) do
+      <<-EOS
+        class file_resource {
+          file { '/tmp/my-file':
+            mode => '0600',
+          }
+        }
+      EOS
+    end
+
+    it 'should not detect any problems' do
+      expect(problems).to have(0).problems
+    end
+  end
+
   context 'class without duplicate parameter' do
     let(:code) do
       <<-EOS


### PR DESCRIPTION
If a class was paramless it was throwing a no such method exception.
This will fix that issue.
