### PR TITLE
Don't lint strings containing already seen variables

### DIFF
--- a/lib/puppet-lint/plugins/duplicate_class_parameters.rb
+++ b/lib/puppet-lint/plugins/duplicate_class_parameters.rb
@@ -16,6 +16,11 @@ PuppetLint.new_check(:duplicate_class_parameters) do
           # handling for lines with an equals and a variable on the rhs
           if next_type == :EQUALS
             inside = true
+
+            two_away = token.next_code_token.next_code_token.type
+            if two_away == :DQPRE
+              inside = false
+            end
           elsif next_type == :COMMA
             inside = false
           end

--- a/spec/puppet-lint/plugins/puppet-lint_duplicate_class_parameters_spec.rb
+++ b/spec/puppet-lint/plugins/puppet-lint_duplicate_class_parameters_spec.rb
@@ -77,6 +77,26 @@ describe 'duplicate_class_parameters' do
     end
   end
 
+  # bug found where a string on the RHS has a variable in it
+  context 'class with variable in a string on right hand side' do
+    let(:code) do
+      <<-EOS
+        class duplicated_string_rhs(
+          $initial  = $sys11mysql,
+          $stringed = "String containing ${initial}",
+        ) {
+          file { '/tmp/my-file':
+            mode => '0600',
+          }
+        }
+      EOS
+    end
+
+    it 'should not detect any problems' do
+      expect(problems).to have(0).problems
+    end
+  end
+
   # Examples that should fail specs
 
   context 'class with duplicate parameters' do


### PR DESCRIPTION
A possible solution to the issue raised in https://github.com/deanwilson/puppet-lint_duplicate_class_parameters-check/issues/8#issuecomment-352030003

@sattelite can you test this change and see if it fixes the issue for you please?